### PR TITLE
Add operator overloaded equivalents for arithmetic operation functions

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -3,8 +3,8 @@ package rex
 import rex.base.*
 
 fun main() {
-    val a = variable("a", 0.0)
-    val b = variable("b", 0.0)
+    val a = "a" by 0
+    val b = "b" by 0
     val lhs = (a + b).pow(2)
     val rhs = a.pow(2) + 2*a*b + b.pow(2)
     println("--- Initial state of expression trees $lhs and $rhs ---")

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -5,8 +5,8 @@ import rex.base.*
 fun main() {
     val a = variable("a", 0.0)
     val b = variable("b", 0.0)
-    val lhs = pow(add(a, b), 2.0)
-    val rhs = add(add(pow(a, 2.0), multiply(multiply(a, b), 2.0)), pow(b, 2.0))
+    val lhs = (a + b).pow(2)
+    val rhs = a.pow(2) + 2*a*b + b.pow(2)
     println("--- Initial state of expression trees $lhs and $rhs ---")
     println("Evaluate lhs: $lhs = ${lhs.evaluate()}")
     println("Evaluate rhs: $rhs = ${rhs.evaluate()}")

--- a/src/main/kotlin/base/Operators.kt
+++ b/src/main/kotlin/base/Operators.kt
@@ -47,3 +47,5 @@ fun Expression.pow(other: Expression): Expression = Power(this, other)
 fun Expression.pow(other: Number): Expression = Power(this, ConstantExpression(other.toDouble()))
 
 fun Number.pow(other: Expression): Expression = Power(ConstantExpression(toDouble()), other)
+
+infix fun String.by(value: Number) = VariableExpression(this, value.toDouble())

--- a/src/main/kotlin/base/Operators.kt
+++ b/src/main/kotlin/base/Operators.kt
@@ -18,6 +18,32 @@ fun divide(self: Expression, other: Double): Expression = Division(self, Constan
 
 fun variable(name: String, value: Double = 0.0) = VariableExpression(name, value)
 
-fun pow(self: Expression, other: Expression): Expression = Power(self, other)
+operator fun Expression.plus(other: Expression): Expression = Addition(this, other)
 
-fun pow(self: Expression, other: Double): Expression = Power(self, ConstantExpression(other))
+operator fun Expression.plus(other: Number): Expression = Addition(this, ConstantExpression(other.toDouble()))
+
+operator fun Number.plus(other: Expression): Expression = Addition(ConstantExpression(toDouble()), other)
+
+operator fun Expression.minus(other: Expression): Expression = Subtraction(this, other)
+
+operator fun Expression.minus(other: Number): Expression = Subtraction(this, ConstantExpression(other.toDouble()))
+
+operator fun Number.minus(other: Expression): Expression = Subtraction(ConstantExpression(toDouble()), other)
+
+operator fun Expression.times(other: Expression): Expression = Multiplication(this, other)
+
+operator fun Expression.times(other: Number): Expression = Multiplication(this, ConstantExpression(other.toDouble()))
+
+operator fun Number.times(other: Expression): Expression = Multiplication(ConstantExpression(toDouble()), other)
+
+operator fun Expression.div(other: Expression): Expression = Division(this, other)
+
+operator fun Expression.div(other: Number): Expression = Division(this, ConstantExpression(other.toDouble()))
+
+operator fun Number.div(other: Expression): Expression = Division(ConstantExpression(toDouble()), other)
+
+fun Expression.pow(other: Expression): Expression = Power(this, other)
+
+fun Expression.pow(other: Number): Expression = Power(this, ConstantExpression(other.toDouble()))
+
+fun Number.pow(other: Expression): Expression = Power(ConstantExpression(toDouble()), other)


### PR DESCRIPTION
With Kotlin operator overloading, we can write expressions in a better readable way. For example, 

`add(add(pow(a, 2.0), multiply(multiply(a, b), 2.0)), pow(b, 2.0))`

is way harder for one to interpret as `a^2 + 2ab + b^2`, but the operator overloaded version

`a.pow(2) + 2*a*b + b.pow(2)`

is way better than the latter one!

Also, I have added a new infix function "by" for declaring variables like `"variable_name" by initial_value`

```kotlin
val x = "x" by 0
val y = "y" by 1
```
How cool is that!!